### PR TITLE
refactor: make algorithm param optional for encrypt decrypt strategy

### DIFF
--- a/src/strategy/Strategy.ts
+++ b/src/strategy/Strategy.ts
@@ -39,11 +39,11 @@ export default abstract class Strategy {
   public abstract getWalletNames(): Promise<{ [addr: string]: string }>;
   public abstract encrypt(
     data: BufferSource,
-    algorithm: RsaOaepParams | AesCtrParams | AesCbcParams | AesGcmParams
+    algorithm?: RsaOaepParams | AesCtrParams | AesCbcParams | AesGcmParams
   ): Promise<Uint8Array>;
   public abstract decrypt(
     data: BufferSource,
-    algorithm: RsaOaepParams | AesCtrParams | AesCbcParams | AesGcmParams
+    algorithm?: RsaOaepParams | AesCtrParams | AesCbcParams | AesGcmParams
   ): Promise<Uint8Array>;
   public abstract getArweaveConfig(): Promise<GatewayConfig>;
   public abstract signature(


### PR DESCRIPTION
## Summary
This PR updates Strategy abstract to make `algorithm` param optional so that it can be compatible with wallet-kit-othent package. Othent doesn't accept algorithm as input from user. Looking at its implementation on server side([see here](https://github.com/Othent/KMS-server-new/blob/4ff20f63ffd4f0272bffb6af4cfbb561f9a35939/src/lib/encrypt.ts#L29)), it shows that othent has to rewrite crypto handling to support this and might be challenging thing to do using Google's kms library.